### PR TITLE
Syntax highlighting improvement

### DIFF
--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -631,6 +631,9 @@
   'interpolated_value':
     'begin': '(?<!\\\\)[#!]\\{(?=.*?\\})'
     'end': '\\}'
+    'captures':
+      '0':
+        'name': 'punctuation.section.embedded.jade'
     'name': 'string.interpolated.jade'
     'patterns': [
       {

--- a/grammars/pyjade.cson
+++ b/grammars/pyjade.cson
@@ -632,6 +632,9 @@
   'interpolated_value':
     'begin': '(?<!\\\\)[#!]\\{(?=.*?\\})'
     'end': '\\}'
+    'captures':
+      '0':
+        'name': 'punctuation.section.embedded.jade'
     'name': 'string.interpolated.jade'
     'patterns': [
       {


### PR DESCRIPTION
Added interpolated_value capture to wrap '#{' and '}'
