### PR TITLE
Support hyphenated coffee-script filter

### DIFF
--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -163,7 +163,7 @@
     ]
   }
   {
-    'begin': '^(\\s*):(coffee(script)?)(?=\\(|$)'
+    'begin': '^(\\s*):(coffee(-?script)?)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.coffeescript.filter.jade'

--- a/grammars/pyjade.cson
+++ b/grammars/pyjade.cson
@@ -164,7 +164,7 @@
     ]
   }
   {
-    'begin': '^(\\s*):(coffee(script)?)(?=\\(|$)'
+    'begin': '^(\\s*):(coffee(-?script)?)(?=\\(|$)'
     'beginCaptures':
       '2':
         'name': 'constant.language.name.coffeescript.filter.jade'


### PR DESCRIPTION
The ":coffeescript" and ":coffee" filters are now deprecated, and jade users must install `jstransformer-coffee-script` and use the filter ":coffee-script" instead. This pull request adds support for the hyphenated version to the grammar so that syntax highlighting is available.