### PR TITLE
Classes highlighted with the correct names

### DIFF
--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -810,7 +810,7 @@
     ]
   'tag_classes':
     'match': '\\.[\\w-]+'
-    'name': 'constant.language.js'
+    'name': 'entity.other.attribute-name.class.jade'
   'tag_id':
     'match': '#[\\w-]+'
     'name': 'entity.other.attribute-name.id.jade'

--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -811,18 +811,14 @@
   'tag_classes':
     'captures':
       '1':
-        'name': 'punctuation.definition.entity.css.jade'
-      '2':
         'name': 'entity.other.attribute-name.class.css.jade'
-    'match': '(\\.)([a-zA-Z0-9_-]+)'
+    'match': '(\\.[a-zA-Z0-9_-]+)'
     'name': 'meta.selector.css.jade'
   'tag_id':
     'captures':
       '1':
-        'name': 'punctuation.definition.entity.css.jade'
-      '2':
         'name': 'entity.other.attribute-name.id.css.jade'
-    'match': '(#)([\\w-]+)'
+    'match': '(#[\\w-]+)'
     'name': 'meta.selector.css.jade'
   'tag_mixin_attributes':
     'begin': '(&attributes\\()'

--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -809,11 +809,21 @@
       }
     ]
   'tag_classes':
-    'match': '\\.[\\w-]+'
-    'name': 'entity.other.attribute-name.class.jade'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.entity.css.jade'
+      '2':
+        'name': 'entity.other.attribute-name.class.css.jade'
+    'match': '(\\.)([a-zA-Z0-9_-]+)'
+    'name': 'meta.selector.css.jade'
   'tag_id':
-    'match': '#[\\w-]+'
-    'name': 'entity.other.attribute-name.id.jade'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.entity.css.jade'
+      '2':
+        'name': 'entity.other.attribute-name.id.css.jade'
+    'match': '(#)([\\w-]+)'
+    'name': 'meta.selector.css.jade'
   'tag_mixin_attributes':
     'begin': '(&attributes\\()'
     'captures':


### PR DESCRIPTION
This package does not provide enough appropriate highlighting,

Using the built in Atom Dark theme class tags and javascript are the same colors,

References #64 

Borrowed the names from the [css grammars code](https://github.com/atom/language-css/blob/177a34a063f4ec126ad7bca0029b542c21358035/grammars/css.cson#L494)