### PR TITLE
Fixed highlighting of Angular2-style event and property bindings

### DIFF
--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -777,11 +777,11 @@
         'captures':
           '1':
             'name': 'entity.other.attribute-name.tag.jade'
-        'match': '([^\\s(),=/]+)\\s*((?=\\))|,|\\s+|$)(?!=)'
+        'match': '([^\\s(),=/]+|\\[[^\\s,=/]+]|\\([^\\s(),=/]+\\))\\s*((?=\\))|,|\\s+|$)(?!=)'
         'name': 'attributes.tag.jade'
       }
       {
-        'begin': '([^\\s(),=/]*[^\\s(),=!/])\\s*(!?\\=)'
+        'begin': '([^\\s,=/]*[^\\s,=!/])\\s*(!?\\=)'
         'beginCaptures':
           '1':
             'name': 'entity.other.attribute-name.tag.jade'

--- a/test/test.jade
+++ b/test/test.jade
@@ -269,3 +269,7 @@ html
         ng-click  = "onFilterRemove()"
         ng-show   = "filter.query !==''"
       )
+      
+      //- angular2 property and event bindings
+      input(type="text", [name]="nameProperty", [(value)]="valueEvent", disabled)
+      input(type="checkbox", [name]="nameProperty", (value)="valueProperty($event)", [disabled], (checked))


### PR DESCRIPTION
The Angular2 style of using ()'s around attribute names to indicate event bindings breaks the current highlighter. This bugfix allows ()'s around attribute names even if they don't have a value, which is unlikely, but legal. The property binding style using []'s still works, as does the combined [()]'s binding syntax. Test cases included.