### PR TITLE
Fixed highlighting of key/value attributes with whitespace before =

### DIFF
--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -777,7 +777,7 @@
         'captures':
           '1':
             'name': 'entity.other.attribute-name.tag.jade'
-        'match': '([^\\s(),=/]+)\\s*((?=\\))|,|\\s+|$)(?!=)'
+        'match': '([^\\s(),=/]+)\\s*((?=\\))|,|\\s+|$)(?!\\s*=)'
         'name': 'attributes.tag.jade'
       }
       {


### PR DESCRIPTION
Resolves #14. Fixed highlighting of key/value attributes with more than one character of whitespace before the equal sign.