### PR TITLE
Fixed comment highlighting broken by previous blank lines

### DIFF
--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -255,7 +255,7 @@
     ]
   }
   {
-    'begin': '^\\s*'
+    'begin': '^\\s*+(?=[^/])'
     'comment': 'All constructs that generally span a single line starting with any number of white-spaces.'
     'end': '$'
     'name': 'tag.jade'


### PR DESCRIPTION
Resolves #16. Stopped tag.jade from running rampant across lines to consume comments. See line 61 in the test file which finally highlights correctly.