### PR TITLE
Jade else flow control tag now properly highlights following lines

### DIFF
--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -506,23 +506,37 @@
       }
     ]
   'flow_control':
-    'begin': '(for|if|else if|else|each|until|while|unless|case)(\\s+|$)'
-    'captures':
-      '1':
-        'name': 'storage.type.function.jade'
-    'comment': 'Jade control flow.'
-    'end': '$'
-    'name': 'meta.control.flow.jade'
     'patterns': [
       {
-        'begin': ''
+        'begin': '(for|if|else if|each|until|while|unless|case)(\\s+|$)'
+        'captures':
+          '1':
+            'name': 'storage.type.function.jade'
+        'comment': 'Jade control flow.'
         'end': '$'
-        'name': 'js.embedded.control.flow.jade'
+        'name': 'meta.control.flow.jade'
         'patterns': [
           {
-            'include': 'source.js'
+            'begin': ''
+            'end': '$'
+            'name': 'js.embedded.control.flow.jade'
+            'patterns': [
+              {
+                'include': 'source.js'
+              }
+            ]
           }
         ]
+      }
+      {
+        'match': '(else)(?! if)\\s*([^\\s].*)?$'
+        'captures':
+          '1':
+            'name': 'storage.type.function.jade'
+          '2':
+            'name': 'invalid.illegal.html_entity.text.jade'
+        'comment': 'Jade control flow.'
+        'name': 'meta.control.flow.jade'
       }
     ]
   'html_entity':


### PR DESCRIPTION
Resolves #22. Split flow control so else is separately handled because it does not allow any condition. Incorrectly formatting else by putting additional text on the same line flags text as invalid. See line 185 in the test file which now highlights correctly.