### PR TITLE
Correct highlighting of text in inline tags

### DIFF
--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -871,7 +871,7 @@
       }
     ]
   'inline_jade_tag_name':
-    'match': '(?<=#\\[|:\\s)([\\w-]+)'
+    'match': '(?<=#\\[|[^\\]]:\\s)([\\w-]+)'
     'name': 'entity.name.tag.jade'
   'tag_text':
     'begin': '(?=.)'

--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -871,8 +871,29 @@
       }
     ]
   'inline_jade_tag_name':
-    'match': '(?<=#\\[|[^\\]]:\\s)([\\w-]+)'
-    'name': 'entity.name.tag.jade'
+    'begin': '(?<=#\\[)'
+    'end': '(?=(?<!:)\\s|\\])'
+    'patterns': [
+      {
+        'match': '((\\w|-|:(?!\\s))+)'
+        'name': 'entity.name.tag.jade'
+      }
+      {
+        'include': '#tag_classes'
+      }
+      {
+        'include': '#tag_id'
+      }
+      {
+        'include': '#tag_attributes'
+      }
+      {
+        'include': '#tag_mixin_attributes'
+      }
+      {
+        'include': '#printed_expression'
+      }
+    ]
   'tag_text':
     'begin': '(?=.)'
     'end': '$'

--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -572,7 +572,7 @@
         'name': 'tag.inline.jade'
         'patterns': [
           {
-            'include': '#tag_name'
+            'include': '#inline_jade_tag_name'
           }
           {
             'include': '#tag_id'
@@ -870,6 +870,9 @@
         ]
       }
     ]
+  'inline_jade_tag_name':
+    'match': '(?<=#\\[)(\\w+)'
+    'name': 'entity.name.tag.jade'
   'tag_text':
     'begin': '(?=.)'
     'end': '$'

--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -871,7 +871,7 @@
       }
     ]
   'inline_jade_tag_name':
-    'match': '(?<=#\\[)(\\w+)'
+    'match': '(?<=#\\[|:\\s)([\\w-]+)'
     'name': 'entity.name.tag.jade'
   'tag_text':
     'begin': '(?=.)'


### PR DESCRIPTION
Hello, @devongovett,

I'm working on improving support for the Jade/Pur syntax in VS Code and noticed that there are a few common problems.

This PR improves support of text in inline tags. For description see #28.

**Before:**

![atom_2016-09-06_00-08-42](https://cloud.githubusercontent.com/assets/7034281/18257120/7083b754-73c7-11e6-976a-a840b232e541.png)

**After:**

![image](https://cloud.githubusercontent.com/assets/7034281/18269615/8a509570-7431-11e6-8d30-91c8c02c48a4.png)

