### PR TITLE
Correct highlighting when including CSS/JS

### DIFF
--- a/grammars/jade.cson
+++ b/grammars/jade.cson
@@ -31,7 +31,7 @@
     ]
   }
   {
-    'begin': '^(\\s*)(script)(?=[.#(\\s])((?![^\\n]*type=)|(?=[^\\n]*text/javascript))'
+    'begin': '^(\\s*)(script)((\\.$)|(?=[.#(].*\\.$))'
     'beginCaptures':
       '2':
         'name': 'entity.name.tag.script.jade'
@@ -65,10 +65,10 @@
     ]
   }
   {
-    'begin': '^(\\s*)(style)(?=[.#(\\s])'
+    'begin': '^(\\s*)(style)((\\.$)|(?=[.#(].*\\.$))'
     'beginCaptures':
       '2':
-        'name': 'entity.name.tag.script.jade'
+        'name': 'entity.name.tag.style.jade'
     'comment': 'Style tag with CSS code.'
     'end': '^(?!(\\1\\s)|\\s*$)'
     'name': 'source.style.jade'

--- a/test/test.jade
+++ b/test/test.jade
@@ -273,3 +273,22 @@ html
       //- angular2 property and event bindings
       input(type="text", [name]="nameProperty", [(value)]="valueEvent", disabled)
       input(type="checkbox", [name]="nameProperty", (value)="valueProperty($event)", [disabled], (checked))
+    
+    // See issue #70 
+    script
+        include ../temp/index.js
+    script(type="text/javascript")
+        include ../temp/index.js
+    script(type="application/javascript")
+        include ../temp/index.js
+    style
+        include ../temp/index.css
+
+    script.
+        var number = 123;
+    script(type="text/javascript").
+        var text = 'text';
+    script(type="application/javascript").
+        var object = {};
+    style.
+        .test { color: #fff }


### PR DESCRIPTION
Hello, @devongovett,

I'm working on improving support for the Jade/Pug syntax in VS Code and noticed that there are a few common problems.

This PR improves highlighitng when including CSS/JS . For description see #70.

Before:

![image](https://cloud.githubusercontent.com/assets/7034281/18347661/5aca51c0-75cf-11e6-9f4b-7d7f184ff36d.png)

After:

![image](https://cloud.githubusercontent.com/assets/7034281/18347568/f7aee4ca-75ce-11e6-8ee8-a32852461f2b.png)
