### PR TITLE
Fix duplicate key problem in snippets

### DIFF
--- a/snippets/language-jade.cson
+++ b/snippets/language-jade.cson
@@ -83,7 +83,7 @@
         'body': 'if ${1:condition}\n  ${2://- code}'
 
 
-    'if/elase condition':
+    'if/else condition':
         'prefix': 'if'
         'body': 'if ${1:condition}\n  ${2://- code}\nelse\n  ${3://- code}'
 

--- a/snippets/language-jade.cson
+++ b/snippets/language-jade.cson
@@ -83,7 +83,7 @@
         'body': 'if ${1:condition}\n  ${2://- code}'
 
 
-    'if condition':
+    'if/elase condition':
         'prefix': 'if'
         'body': 'if ${1:condition}\n  ${2://- code}\nelse\n  ${3://- code}'
 


### PR DESCRIPTION
This was causing an error in Atom v1.23.1

![image](https://user-images.githubusercontent.com/10676525/34917174-1566a78e-f943-11e7-9920-d16ce200d28d.png)
