### PR TITLE
Fix duplicate snippet key

### DIFF
--- a/snippets/language-jade.cson
+++ b/snippets/language-jade.cson
@@ -83,7 +83,7 @@
         'body': 'if ${1:condition}\n  ${2://- code}'
 
 
-    'if condition':
+    'if else condition':
         'prefix': 'if'
         'body': 'if ${1:condition}\n  ${2://- code}\nelse\n  ${3://- code}'
 


### PR DESCRIPTION
Atom has added a check for duplicate snippet keys, fix the key for this to note that it includes an `else` condition.

Fixes #77.